### PR TITLE
Fix database file creation on vps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,20 +3,22 @@ FROM python:3.11-slim
 # Définir le répertoire de travail
 WORKDIR /app
 
-# Copier les fichiers de requirements
-COPY requirements.txt .
+# Créer un utilisateur non-root dès le début
+RUN useradd -m -u 1000 botuser
+
+# Copier les fichiers de requirements avec le bon propriétaire
+COPY --chown=botuser:botuser requirements.txt .
 
 # Installer les dépendances Python
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copier le reste de l'application
-COPY . .
+# Copier le reste de l'application avec le bon propriétaire
+COPY --chown=botuser:botuser . .
 
-# Créer le dossier data avec les bonnes permissions
-RUN mkdir -p /app/data
+# Créer le dossier data et définir les permissions
+RUN mkdir -p /app/data && chown -R botuser:botuser /app/data
 
-# Créer un utilisateur non-root pour la sécurité
-RUN useradd -m -u 1000 botuser && chown -R botuser:botuser /app
+# Changer vers l'utilisateur non-root
 USER botuser
 
 # Commande pour lancer le bot

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Script de déploiement pour PickTag2GetRole
+
+echo "📦 Mise à jour du code..."
+git pull
+
+echo "🛑 Arrêt du conteneur..."
+docker-compose down
+
+echo "🔨 Construction de l'image (sans cache)..."
+docker-compose build --no-cache
+
+echo "🚀 Démarrage du bot..."
+docker-compose up -d
+
+echo "📋 Affichage des logs..."
+docker-compose logs -f


### PR DESCRIPTION
Create `/app/data` directory in Dockerfile to ensure `botuser` has write permissions for the database.

The bot was failing to open the database file with `sqlite3.OperationalError: unable to open database file` because the `botuser` did not have write permissions in `/app/data`. By creating the directory before changing ownership of `/app` to `botuser`, the `data` directory now inherits the correct permissions.

---
<a href="https://cursor.com/background-agent?bcId=bc-39480af8-edef-4da0-aa35-3649634ff592">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-39480af8-edef-4da0-aa35-3649634ff592">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

