### PR TITLE
Investigate role removal bug for tagged members

### DIFF
--- a/FIX_SCAN_BUG.md
+++ b/FIX_SCAN_BUG.md
@@ -1,0 +1,47 @@
+# Correction du bug de la commande /scan
+
+## Problème identifié
+
+La commande `/scan` supprimait les rôles des membres qui avaient pourtant le tag configuré dans leur statut personnalisé.
+
+## Causes du problème
+
+1. **Méthode `fetch_members()`** : Cette méthode Discord ne récupère pas toutes les informations des membres, notamment :
+   - Les activités (statuts personnalisés)
+   - Les présences
+   
+2. **Intent `presences` manquant** : Le bot n'avait pas l'intent `presences` activé, ce qui est nécessaire pour accéder aux activités et statuts personnalisés des membres.
+
+## Solutions appliquées
+
+### 1. Modification de la méthode de récupération des membres
+
+Dans `/workspace/cogs/commands.py` (ligne 225) :
+- **Avant** : `async for member in interaction.guild.fetch_members(limit=None):`
+- **Après** : `for member in interaction.guild.members:`
+
+L'utilisation de `guild.members` permet d'accéder aux données en cache qui incluent les activités et présences.
+
+### 2. Activation de l'intent `presences`
+
+Dans `/workspace/bot.py` (ligne 18) :
+- Ajout de : `intents.presences = True`
+
+Ceci est nécessaire pour que Discord envoie les informations de présence et d'activité au bot.
+
+### 3. Ajout de logs de débogage
+
+Des logs ont été ajoutés pour faciliter le débogage futur :
+- Dans la commande `/scan` pour tracer les membres avec le tag
+- Dans la méthode `_member_has_tag` (commenté par défaut)
+
+## Impact
+
+Ces modifications permettent à la commande `/scan` de :
+- Détecter correctement les tags dans les statuts personnalisés
+- Ne plus supprimer les rôles des membres qui ont le tag
+- Fonctionner de manière cohérente avec le monitoring en temps réel
+
+## Note importante
+
+⚠️ **L'intent `presences` doit être activé dans les paramètres du bot sur Discord Developer Portal** pour que ces modifications fonctionnent correctement.

--- a/bot.py
+++ b/bot.py
@@ -15,6 +15,7 @@ load_dotenv()
 intents = discord.Intents.default()
 intents.guilds = True
 intents.members = True
+intents.presences = True  # Nécessaire pour voir les activités/statuts personnalisés
 intents.guild_messages = False  # Désactiver les messages pour économiser des ressources
 intents.message_content = False
 

--- a/cogs/commands.py
+++ b/cogs/commands.py
@@ -221,9 +221,14 @@ class ConfigCommands(commands.Cog):
         members_updated = 0
         total_members = 0
         
-        async for member in interaction.guild.fetch_members(limit=None):
+        # Utiliser guild.members pour avoir accès aux données en cache (incluant les activités)
+        for member in interaction.guild.members:
             total_members += 1
             has_tag = tag_monitor._member_has_tag(member, tag_to_watch)
+            
+            # Log de débogage
+            if has_tag:
+                print(f"[SCAN] {member.name} has tag '{tag_to_watch}' - display_name: {member.display_name}, activity: {member.activity}")
             
             # Vérifier si le membre doit avoir les rôles
             needs_update = False
@@ -237,6 +242,7 @@ class ConfigCommands(commands.Cog):
                         needs_update = True
             
             if needs_update:
+                print(f"[SCAN] Updating roles for {member.name} - has_tag: {has_tag}")
                 await tag_monitor._update_member_roles(member, has_tag, role_ids)
                 members_updated += 1
         

--- a/cogs/tag_monitor.py
+++ b/cogs/tag_monitor.py
@@ -59,7 +59,10 @@ class TagMonitor(commands.Cog):
             if isinstance(member.activity, discord.CustomActivity) and member.activity.name:
                 if tag.lower() in member.activity.name.lower():
                     return True
-            
+        
+        # Log de débogage pour les membres sans tag
+        # print(f"[TAG_CHECK] {member.name} - display_name: {member.display_name}, activity: {getattr(member, 'activity', None)}, has_tag: False")
+        
         return False
     
     async def _update_member_roles(self, member: discord.Member, should_have_roles: bool, role_ids: List[int]):


### PR DESCRIPTION
Fix the `/scan` command to correctly detect tags in custom statuses, preventing incorrect role removal.

The previous implementation failed to detect tags in custom statuses because the bot lacked the `presences` intent and used `fetch_members()`, which doesn't guarantee full presence data. This led to members with tags in their custom status having their roles incorrectly removed.

---
<a href="https://cursor.com/background-agent?bcId=bc-170561ee-17cf-4ddc-b924-15ba3e4b8b43">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-170561ee-17cf-4ddc-b924-15ba3e4b8b43">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

