### PR TITLE
Remove debug from scan command

### DIFF
--- a/cogs/tag_monitor.py
+++ b/cogs/tag_monitor.py
@@ -224,11 +224,11 @@ class TagMonitor(commands.Cog):
             
             # Comparaison exacte du tag (insensible à la casse)
             if pg.tag.lower() == tag.lower():
-                logger.info(f"✅ {member.name} has matching tag: {pg.tag}")
+                logger.debug(f"✅ {member.name} has matching tag: {pg.tag}")
                 return True
             # Si le tag configuré contient un #, essayer une correspondance partielle
             elif '#' in tag and tag.lower() in pg.tag.lower():
-                logger.info(f"✅ {member.name} has partial matching tag: {pg.tag} (looking for {tag})")
+                logger.debug(f"✅ {member.name} has partial matching tag: {pg.tag} (looking for {tag})")
                 return True
             else:
                 logger.debug(f"{member.name} has different tag: '{pg.tag}' (looking for '{tag}')")


### PR DESCRIPTION
Remove the `debug` parameter from the `/scan` command because it was a development-only feature not intended for general users.

---
<a href="https://cursor.com/background-agent?bcId=bc-cfe1bb6a-5a4d-4ac6-baf9-08b1466bcbdc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cfe1bb6a-5a4d-4ac6-baf9-08b1466bcbdc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

